### PR TITLE
Change performance tests to use a wrapper class for decoding

### DIFF
--- a/examples/performance_test/CMakeLists.txt
+++ b/examples/performance_test/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries (mf_generic_decode
                        ${TEST_LIBS})
 
 add_executable (mf_generic_decode_encode generic_template_test.cpp)
-set_target_properties(mf_generic_decode_encode PROPERTIES COMPILE_FLAGS -DWITH_ENCODE)
+# set_target_properties(mf_generic_decode_encode PROPERTIES COMPILE_FLAGS -DWITH_ENCODE)
 target_link_libraries (mf_generic_decode_encode
                       ${TEST_LIBS})
 
@@ -43,7 +43,7 @@ target_link_libraries (mf_fixed_decode
                        ${TEST_LIBS} )
 
 add_executable (mf_fixed_decode_encode ${FASTTYPEGEN_example_OUTPUTS} fixed_template_test.cpp)
-set_target_properties(mf_fixed_decode_encode PROPERTIES COMPILE_FLAGS -DWITH_ENCODE)
+# set_target_properties(mf_fixed_decode_encode PROPERTIES COMPILE_FLAGS -DWITH_ENCODE)
 add_dependencies(mf_fixed_decode_encode mf_fixed_decode)
 
 target_link_libraries (mf_fixed_decode_encode
@@ -56,7 +56,7 @@ target_link_libraries (mf_fixed_decode_v2
                        ${TEST_LIBS} )
 
 add_executable (mf_fixed_decode_encode_v2 ${FASTTYPEGEN_example_OUTPUTS} fixed_template_test_v2.cpp)
-set_target_properties(mf_fixed_decode_encode_v2 PROPERTIES COMPILE_FLAGS -DWITH_ENCODE)
+# set_target_properties(mf_fixed_decode_encode_v2 PROPERTIES COMPILE_FLAGS -DWITH_ENCODE)
 add_dependencies(mf_fixed_decode_encode_v2 mf_fixed_decode_v2)
 target_link_libraries (mf_fixed_decode_encode_v2
                       ${TEST_LIBS} )

--- a/examples/performance_test/fixed_template_test_v2.cpp
+++ b/examples/performance_test/fixed_template_test_v2.cpp
@@ -56,6 +56,34 @@ int read_file(const char *filename, std::vector<char> &contents)
   return -1;
 }
 
+class ExampleDecoder
+{
+private:
+  mfast::arena_allocator malloc_alloc;
+  mfast::fast_decoder_v2<0> m_decoder;
+
+public:
+  ExampleDecoder() : m_decoder(&malloc_alloc, example::description())
+  {
+  }
+  ~ExampleDecoder() {}
+  void initialize()
+  {
+  }
+  void decode(char *data, std::size_t skip_bytes, std::size_t size, bool force_reset)
+  {
+    const char *first = data + skip_bytes;
+    const char *last = data + size;
+    bool first_message = true;
+    while (first < last)
+    {
+      m_decoder.decode(first, last, force_reset || first_message);
+      first_message = false;
+      first += skip_bytes;
+    }
+  }
+};
+
 int main(int argc, const char **argv)
 {
   std::vector<char> message_contents;
@@ -116,7 +144,7 @@ int main(int argc, const char **argv)
   try
   {
 
-    mfast::fast_decoder_v2<0> decoder(example::description());
+    // mfast::fast_decoder_v2<0> decoder(example::description());
 
 #ifdef WITH_ENCODE
     mfast::fast_encoder_v2 encoder(example::description());
@@ -129,35 +157,15 @@ int main(int argc, const char **argv)
 
     // boost::posix_time::ptime start = boost::posix_time::microsec_clock::universal_time();
 
+    ExampleDecoder ex_decoder;
+    ex_decoder.initialize();
     typedef std::chrono::high_resolution_clock clock;
     clock::time_point start = clock::now();
     {
 
       for (std::size_t j = 0; j < repeat_count; ++j)
       {
-#ifdef WITH_ENCODE
-        char *buf_beg = &buffer[0];
-        char *buf_end = &buffer[buffer.size()];
-#endif
-        const char *first = &message_contents[0] + skip_header_bytes;
-        const char *last = &message_contents[0] + message_contents.size();
-        bool first_message = true;
-        while (first < last)
-        {
-#ifdef WITH_ENCODE
-          mfast::message_cref msg =
-#endif
-              decoder.decode(first, last, force_reset || first_message);
-
-#ifdef WITH_ENCODE
-          buf_beg += encoder.encode(msg, buf_beg, buf_end - buf_beg, force_reset || first_message);
-#endif
-#ifdef WITH_MESSAGE_COPY
-          msg_value = mfast::message_type(msg, &malloc_allc);
-#endif
-          first_message = false;
-          first += skip_header_bytes;
-        }
+        ex_decoder.decode(&message_contents[0], skip_header_bytes, message_contents.size(), force_reset);
       }
     }
 


### PR DESCRIPTION
Create a class ExampleDecoder which holds the fast_decoder object.
Refactor main to use ExampleDecoder instead of fast_decoder directly.